### PR TITLE
Add flexible URL parsing and CLI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
-A 403 bypasser writen in golang
+## 4go3
 
-I really liked the name, the main point of making this tool was claming the name. *and maybe to learn go but mostly the name*
+A 403 bypasser written in Go. The project now follows a conventional Go layout with the entry point under `cmd/4go3` and reusable packages living in `internal/`.
+
+### Usage
+
+```
+go run ./cmd/4go3 -url https://example.org/test1/test2/test3?user=3 -segment test2
+```
+
+Key flags:
+
+* `-url`/`-u` – Target URL. Schemes default to `https://` when omitted.
+* `-segment`/`-path` – Named path segment to fuzz. When omitted, the last segment is used.
+* `-segment-index` – Zero-based index of the segment to fuzz. Useful for duplicate segment names.
+* `-query`/`-q` – Additional query parameters in `key=value` form.
+* `-threads`/`-t`, `-rate`, `-timeout` – Worker pool configuration.
+* `-header`/`-H` – Repeatable custom headers.
+
+Segments following the chosen target are preserved, so for `https://example.org/test1/test2/test3` you can fuzz `test1`, `test2`, or `test3` independently without losing the surrounding path. Query strings and fragments supplied in the URL are automatically carried into every generated request.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ go run ./cmd/4go3 -url https://example.org/test1/test2/test3?user=3 -segment tes
 Key flags:
 
 * `-url`/`-u` – Target URL. Schemes default to `https://` when omitted.
-* `-segment`/`-path` – Named path segment to fuzz. When omitted, the last segment is used.
-* `-segment-index` – Zero-based index of the segment to fuzz. Useful for duplicate segment names.
+* `-segment`/`-path` – Named path segment to fuzz.
+* `-segment-index` – Zero-based index of the segment to fuzz. Useful for duplicate segment names. When neither `-segment` nor `-segment-index` is supplied, the CLI lists the available path segments and lets you pick interactively.
 * `-query`/`-q` – Additional query parameters in `key=value` form.
 * `-threads`/`-t`, `-rate`, `-timeout` – Worker pool configuration.
 * `-header`/`-H` – Repeatable custom headers.

--- a/cmd/4go3/main.go
+++ b/cmd/4go3/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/florran/4go3/internal/config"
 	"github.com/florran/4go3/internal/jobs"
@@ -10,7 +12,11 @@ import (
 
 func main() {
 
-	userConfig := config.ParseFlags()
+	userConfig, err := config.ParseFlags()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 
 	jobs := jobs.GenerateJobs(userConfig)
 

--- a/internal/bypass/bypass.go
+++ b/internal/bypass/bypass.go
@@ -1,11 +1,6 @@
 package bypass
 
-import (
-	"fmt"
-	"strings"
-)
-
-var BypassHeaders = []map[string][]string{
+var HeaderPayloads = []map[string][]string{
 	{"Client-IP": {"127.0.0.1"}},
 	{"Forwarded-For-Ip": {"127.0.0.1"}},
 	{"Forwarded-For": {"127.0.0.1"}},
@@ -45,7 +40,7 @@ var BypassHeaders = []map[string][]string{
 	{"X-True-IP": {"127.0.0.1"}},
 }
 
-var PathBypassPatterns = []string{
+var PathPatterns = []string{
 	"%s/./%s",       // https://example.com/./admin
 	"%s/../%s",      // https://example.com/../admin
 	"%s/%%2e/%s",    // https://example.com/%2e/admin
@@ -67,7 +62,7 @@ var PathBypassPatterns = []string{
 	"%s//;//%s",     // https://example.com//;//admin/
 }
 
-var HttpMethods = [9]string{
+var HTTPMethods = [9]string{
 	"GET",
 	"POST",
 	"PUT",
@@ -77,16 +72,4 @@ var HttpMethods = [9]string{
 	"OPTIONS",
 	"CONNECT",
 	"TRACE",
-}
-
-func GenerateBypassPaths(url string, path string) []string {
-
-	var bypassPaths []string
-
-	bypassPaths = append(bypassPaths, fmt.Sprintf("%s/%s", url, strings.ToUpper(path)))
-
-	for _, pattern := range PathBypassPatterns {
-		bypassPaths = append(bypassPaths, fmt.Sprintf(pattern, url, path))
-	}
-	return bypassPaths
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,12 +1,15 @@
 package config
 
 import (
+	"bufio"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -168,7 +171,11 @@ func ParseFlags() (Config, error) {
 		}
 		cfg.TargetSegmentIndex = idx
 	case len(cfg.PathSegments) > 0:
-		cfg.TargetSegmentIndex = len(cfg.PathSegments) - 1
+		idx, err := promptForSegmentIndex(cfg.PathSegments)
+		if err != nil {
+			return Config{}, err
+		}
+		cfg.TargetSegmentIndex = idx
 	}
 
 	if cfg.Rate < 1 {
@@ -184,6 +191,55 @@ func ParseFlags() (Config, error) {
 	cfg.Timeout = time.Duration(timeout) * time.Second
 
 	return cfg, nil
+}
+
+func promptForSegmentIndex(segments []string) (int, error) {
+	if len(segments) == 0 {
+		return -1, errors.New("no path segments available for selection")
+	}
+
+	fmt.Fprintln(os.Stdout, "Available path segments to fuzz:")
+	for idx, segment := range segments {
+		fmt.Fprintf(os.Stdout, "  [%d] %s\n", idx, segment)
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Fprintf(os.Stdout, "Select segment index [0-%d]: ", len(segments)-1)
+		input, err := reader.ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return -1, err
+		}
+
+		input = strings.TrimSpace(input)
+		if input == "" {
+			if errors.Is(err, io.EOF) {
+				return -1, errors.New("no segment index selected")
+			}
+			fmt.Fprintln(os.Stdout, "Please enter a value.")
+			continue
+		}
+
+		selected, convErr := strconv.Atoi(input)
+		if convErr != nil {
+			if errors.Is(err, io.EOF) {
+				return -1, convErr
+			}
+			fmt.Fprintf(os.Stdout, "Invalid index %q. Please enter a number between 0 and %d.\n", input, len(segments)-1)
+			continue
+		}
+
+		if selected < 0 || selected >= len(segments) {
+			rangeErr := fmt.Errorf("segment-index %d out of range", selected)
+			if errors.Is(err, io.EOF) {
+				return -1, rangeErr
+			}
+			fmt.Fprintf(os.Stdout, "%s. Please enter a number between 0 and %d.\n", rangeErr.Error(), len(segments)-1)
+			continue
+		}
+
+		return selected, nil
+	}
 }
 
 func (c Config) TargetSegment() string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,110 +1,291 @@
 package config
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"net/url"
+	"os"
+	"sort"
 	"strings"
 	"time"
 )
 
 type Config struct {
-	URL         string
-	Path        string
-	QueryParams string
-	Threads     int
-	Rate        float64
-	Headers     map[string][]string
-	Timeout     time.Duration
+	RawURL             string
+	BaseURL            string
+	PathSegments       []string
+	TargetSegmentIndex int
+	Threads            int
+	Rate               float64
+	Headers            map[string][]string
+	Timeout            time.Duration
+	Query              url.Values
+	Fragment           string
+
+	parsedURL url.URL
 }
 
 func flagsHelp() {
-	fmt.Println("\n-u Target URL (e.g. https://example.com or http://example.com), if no protocol is defined (e.g. example.com) https:// is used")
-	fmt.Println("\n-path Last URL segment to tamper (e.g. admin for https://example.com/panel/admin)")
-	fmt.Println("\n-q Query parameters (e.g., key1=value1) use multiple flags for multiple parameters")
-	fmt.Println("\n-t Number of concurrent threads (default: 10)")
-	fmt.Println("\n-rate Number of recuests per second (default: 5)")
-	fmt.Println("\n-max-time Max time per request in seconds")
-	fmt.Println("\n-H Headers to include in requests (e.g. \"Referer: https://example.com\") use multiple flags for multiple headers")
-	fmt.Println("")
+	fmt.Fprintln(os.Stderr, "Usage of 4go3:")
+	fmt.Fprintln(os.Stderr, "  -url, -u string")
+	fmt.Fprintln(os.Stderr, "        Target URL. Schemes will default to https when omitted (e.g. example.com)")
+	fmt.Fprintln(os.Stderr, "  -segment string")
+	fmt.Fprintln(os.Stderr, "        Path segment to fuzz (e.g. admin)")
+	fmt.Fprintln(os.Stderr, "  -segment-index int")
+	fmt.Fprintln(os.Stderr, "        Zero-based index for the segment to fuzz. Overrides -segment when supplied")
+	fmt.Fprintln(os.Stderr, "  -query, -q string")
+	fmt.Fprintln(os.Stderr, "        Additional query parameter in key=value form. Repeat for multiple entries")
+	fmt.Fprintln(os.Stderr, "  -threads, -t int")
+	fmt.Fprintln(os.Stderr, "        Number of concurrent workers (default 10)")
+	fmt.Fprintln(os.Stderr, "  -rate float")
+	fmt.Fprintln(os.Stderr, "        Requests per second (default 5)")
+	fmt.Fprintln(os.Stderr, "  -timeout int")
+	fmt.Fprintln(os.Stderr, "        Request timeout in seconds (default 10)")
+	fmt.Fprintln(os.Stderr, "  -header, -H string")
+	fmt.Fprintln(os.Stderr, "        Custom header in the form \"Key: Value\". Repeat for multiple entries")
 }
 
-func ParseFlags() Config {
-	var userConfig Config
-	var timeout int
+func ParseFlags() (Config, error) {
+	var (
+		rawURL       string
+		segmentValue string
+		segmentIndex int
+		timeout      int
 
-	userConfig.Headers = make(map[string][]string)
+		headers = make(map[string][]string)
+		queries = url.Values{}
+	)
+
+	cfg := Config{
+		Headers:            headers,
+		TargetSegmentIndex: -1,
+	}
 
 	flag.Usage = flagsHelp
 
-	flag.StringVar(&userConfig.URL, "u", "", "Target URL (e.g., https://example.com)")
+	flag.StringVar(&rawURL, "url", "", "Target URL (e.g. https://example.com)")
+	flag.StringVar(&rawURL, "u", "", "Target URL (e.g. https://example.com)")
 
-	flag.StringVar(&userConfig.Path, "path", "", "Path to tamper (e.g., admin-panel)")
+	flag.StringVar(&segmentValue, "segment", "", "Path segment to fuzz")
+	flag.StringVar(&segmentValue, "path", "", "Alias for -segment")
 
-	flag.IntVar(&userConfig.Threads, "t", 10, "Number of concurrent threads (workers)")
+	flag.IntVar(&segmentIndex, "segment-index", -1, "Zero-based index for the segment to fuzz")
 
-	flag.Float64Var(&userConfig.Rate, "rate", 5, "Requests per second default ")
+	flag.IntVar(&cfg.Threads, "threads", 10, "Number of concurrent threads (workers)")
+	flag.IntVar(&cfg.Threads, "t", 10, "Number of concurrent threads (workers)")
 
-	flag.IntVar(&timeout, "max-time", 10, "Max time per request in seconds")
+	flag.Float64Var(&cfg.Rate, "rate", 5, "Requests per second")
 
-	flag.Func("q", "-q Query parameters (e.g., key1=value1) use multiple flags for multiple parameters", func(q string) error {
-		parts := strings.SplitN(q, "=", 2)
-		if len(parts) != 2 {
-			return fmt.Errorf("invalid query parameter format: %s", q)
+	flag.IntVar(&timeout, "timeout", 10, "Request timeout in seconds")
+	flag.IntVar(&timeout, "max-time", 10, "Alias for timeout")
+
+	flag.Func("query", "Query parameter (key=value)", func(q string) error {
+		key, value, err := parseKeyValue(q, "=")
+		if err != nil {
+			return err
 		}
-
-		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-
-		if key == "" || value == "" {
-			return fmt.Errorf("invalid query parameter: %s", q)
+		queries.Add(key, value)
+		return nil
+	})
+	flag.Func("q", "Query parameter (key=value)", func(q string) error {
+		key, value, err := parseKeyValue(q, "=")
+		if err != nil {
+			return err
 		}
-
-		if userConfig.QueryParams != "" {
-			userConfig.QueryParams += "&"
-		}
-		userConfig.QueryParams += fmt.Sprintf("%s=%s", key, value)
-
+		queries.Add(key, value)
 		return nil
 	})
 
-	flag.Func("H", "Used to set custom headers", func(h string) error {
-		parts := strings.SplitN(h, ":", 2)
-		if len(parts) != 2 {
-			return fmt.Errorf("invalid header format: %s", h)
+	flag.Func("header", "Custom header (Key: Value)", func(h string) error {
+		key, value, err := parseKeyValue(h, ":")
+		if err != nil {
+			return err
 		}
-
-		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-		userConfig.Headers[key] = append(userConfig.Headers[key], value)
-
+		headers[key] = append(headers[key], value)
+		return nil
+	})
+	flag.Func("H", "Custom header (Key: Value)", func(h string) error {
+		key, value, err := parseKeyValue(h, ":")
+		if err != nil {
+			return err
+		}
+		headers[key] = append(headers[key], value)
 		return nil
 	})
 
 	flag.Parse()
 
-	if userConfig.URL == "" {
-		fmt.Println("Usage: -u <URL> [-path path] [-t threads] [-rate requests per second]")
-		return Config{}
+	if rawURL == "" {
+		return Config{}, errors.New("missing required -url flag")
 	}
 
-	if !strings.HasPrefix(userConfig.URL, "http") {
-		userConfig.URL = "https://" + userConfig.URL
+	normalizedURL := rawURL
+	if !strings.Contains(normalizedURL, "://") {
+		normalizedURL = "https://" + normalizedURL
 	}
 
-	if userConfig.Rate < 1 {
-		fmt.Println("Rate must be greater than 1 defaulting to 1 (slowest)")
-		userConfig.Rate = 1
+	parsed, err := url.Parse(normalizedURL)
+	if err != nil {
+		return Config{}, fmt.Errorf("invalid url: %w", err)
 	}
 
-	if userConfig.Threads < 1 {
-		fmt.Println("Threads must be greater than 1 defaulting to 1 (leasts work)")
-		userConfig.Threads = 1
-	}
-	userConfig.URL = strings.TrimSuffix(userConfig.URL, "/")
-	userConfig.Path = strings.TrimPrefix(userConfig.Path, "/")
-	userConfig.Timeout = time.Duration(timeout) * time.Second
+	cfg.RawURL = normalizedURL
+	cfg.BaseURL = (&url.URL{Scheme: parsed.Scheme, Host: parsed.Host}).String()
+	cfg.parsedURL = *parsed
 
-	return userConfig
+	cfg.Query = parsed.Query()
+	cfg.Fragment = parsed.Fragment
+
+	for key, values := range queries {
+		for _, value := range values {
+			cfg.Query.Add(key, value)
+		}
+	}
+
+	cfg.parsedURL.RawQuery = ""
+	cfg.parsedURL.Fragment = ""
+
+	trimmedPath := strings.Trim(parsed.Path, "/")
+	if trimmedPath != "" {
+		cfg.PathSegments = strings.Split(trimmedPath, "/")
+	}
+
+	if len(cfg.PathSegments) == 0 && (segmentValue != "" || segmentIndex >= 0) {
+		return Config{}, errors.New("the provided URL does not contain path segments to fuzz")
+	}
+
+	switch {
+	case segmentIndex >= 0:
+		if segmentIndex >= len(cfg.PathSegments) {
+			return Config{}, fmt.Errorf("segment-index %d out of range", segmentIndex)
+		}
+		cfg.TargetSegmentIndex = segmentIndex
+	case segmentValue != "":
+		idx := indexOf(cfg.PathSegments, segmentValue)
+		if idx == -1 {
+			return Config{}, fmt.Errorf("segment %q not found in url", segmentValue)
+		}
+		cfg.TargetSegmentIndex = idx
+	case len(cfg.PathSegments) > 0:
+		cfg.TargetSegmentIndex = len(cfg.PathSegments) - 1
+	}
+
+	if cfg.Rate < 1 {
+		fmt.Fprintln(os.Stderr, "rate must be greater than or equal to 1; defaulting to 1")
+		cfg.Rate = 1
+	}
+
+	if cfg.Threads < 1 {
+		fmt.Fprintln(os.Stderr, "threads must be greater than or equal to 1; defaulting to 1")
+		cfg.Threads = 1
+	}
+
+	cfg.Timeout = time.Duration(timeout) * time.Second
+
+	return cfg, nil
+}
+
+func (c Config) TargetSegment() string {
+	if !c.HasTargetSegment() {
+		return ""
+	}
+	return c.PathSegments[c.TargetSegmentIndex]
+}
+
+func (c Config) HasTargetSegment() bool {
+	return c.TargetSegmentIndex >= 0 && c.TargetSegmentIndex < len(c.PathSegments)
+}
+
+func (c Config) PrefixSegments() []string {
+	if !c.HasTargetSegment() {
+		return nil
+	}
+	return append([]string{}, c.PathSegments[:c.TargetSegmentIndex]...)
+}
+
+func (c Config) SuffixSegments() []string {
+	if !c.HasTargetSegment() {
+		return nil
+	}
+	return append([]string{}, c.PathSegments[c.TargetSegmentIndex+1:]...)
+}
+
+func (c Config) DefaultURL() string {
+	return c.buildURLWithSegments(c.PathSegments)
+}
+
+func (c Config) TargetPrefixURL() string {
+	base := c.parsedURL
+	base.Path = ""
+	if prefix := c.PrefixSegments(); len(prefix) > 0 {
+		base.Path = "/" + strings.Join(prefix, "/")
+	}
+	return strings.TrimSuffix(base.String(), "/")
+}
+
+func (c Config) BuildURLForVariant(variant string) string {
+	if !c.HasTargetSegment() {
+		return c.DefaultURL()
+	}
+
+	segments := append([]string{}, c.PathSegments...)
+	segments[c.TargetSegmentIndex] = variant
+	return c.buildURLWithSegments(segments)
+}
+
+func (c Config) AppendSuffixAndQuery(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+
+	suffix := c.SuffixSegments()
+	if len(suffix) > 0 {
+		path := parsed.Path
+		if path == "" {
+			path = "/"
+		}
+		if !strings.HasSuffix(path, "/") {
+			path += "/"
+		}
+		path += strings.Join(suffix, "/")
+		parsed.Path = path
+	}
+
+	if len(c.Query) > 0 {
+		parsed.RawQuery = encodeQuery(c.Query)
+	} else {
+		parsed.RawQuery = ""
+	}
+	parsed.Fragment = c.Fragment
+
+	if parsed.Scheme == "" {
+		parsed.Scheme = c.parsedURL.Scheme
+	}
+	if parsed.Host == "" {
+		parsed.Host = c.parsedURL.Host
+	}
+
+	return parsed.String()
+}
+
+func (c Config) buildURLWithSegments(segments []string) string {
+	builder := c.parsedURL
+	if len(segments) > 0 {
+		builder.Path = "/" + strings.Join(segments, "/")
+	} else {
+		builder.Path = ""
+	}
+
+	if len(c.Query) > 0 {
+		builder.RawQuery = encodeQuery(c.Query)
+	} else {
+		builder.RawQuery = ""
+	}
+	builder.Fragment = c.Fragment
+
+	return builder.String()
 }
 
 func MergeHeaders(primaryHeaders, secondaryHeaders map[string][]string) map[string][]string {
@@ -119,4 +300,52 @@ func MergeHeaders(primaryHeaders, secondaryHeaders map[string][]string) map[stri
 	}
 
 	return merged
+}
+
+func parseKeyValue(input, delimiter string) (string, string, error) {
+	parts := strings.SplitN(input, delimiter, 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid value %q", input)
+	}
+
+	key := strings.TrimSpace(parts[0])
+	value := strings.TrimSpace(parts[1])
+
+	if key == "" || value == "" {
+		return "", "", fmt.Errorf("invalid value %q", input)
+	}
+
+	return key, value, nil
+}
+
+func indexOf(values []string, target string) int {
+	for i, value := range values {
+		if value == target {
+			return i
+		}
+	}
+	return -1
+}
+
+func encodeQuery(values url.Values) string {
+	if values == nil {
+		return ""
+	}
+	clone := url.Values{}
+	for key, vals := range values {
+		clone[key] = append([]string{}, vals...)
+	}
+	keys := make([]string, 0, len(clone))
+	for key := range clone {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	ordered := url.Values{}
+	for _, key := range keys {
+		for _, value := range clone[key] {
+			ordered.Add(key, value)
+		}
+	}
+	return ordered.Encode()
 }

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -2,84 +2,12 @@ package jobs
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
+	"github.com/florran/4go3/internal/bypass"
 	"github.com/florran/4go3/internal/config"
 )
-
-var BypassHeaders = []map[string][]string{
-	{"Client-IP": {"127.0.0.1"}},
-	{"Forwarded-For-Ip": {"127.0.0.1"}},
-	{"Forwarded-For": {"127.0.0.1"}},
-	{"Forwarded-For": {"localhost"}},
-	{"Forwarded": {"127.0.0.1"}},
-	{"Forwarded": {"localhost"}},
-	{"True-Client-IP": {"127.0.0.1"}},
-	{"X-Client-IP": {"127.0.0.1"}},
-	{"X-Custom-IP-Authorization": {"127.0.0.1"}},
-	{"X-Forward-For": {"127.0.0.1"}},
-	{"X-Forward": {"127.0.0.1"}},
-	{"X-Forward": {"localhost"}},
-	{"X-Forwarded-By": {"127.0.0.1"}},
-	{"X-Forwarded-By": {"localhost"}},
-	{"X-Forwarded-For-Original": {"127.0.0.1"}},
-	{"X-Forwarded-For-Original": {"localhost"}},
-	{"X-Forwarded-For": {"127.0.0.1"}},
-	{"X-Forwarded-For": {"localhost"}},
-	{"X-Forwarded-Server": {"127.0.0.1"}},
-	{"X-Forwarded-Server": {"localhost"}},
-	{"X-Forwarded": {"127.0.0.1"}},
-	{"X-Forwarded": {"localhost"}},
-	{"X-Forwared-Host": {"127.0.0.1"}},
-	{"X-Forwared-Host": {"localhost"}},
-	{"X-Host": {"127.0.0.1"}},
-	{"X-Host": {"localhost"}},
-	{"X-HTTP-Host-Override": {"127.0.0.1"}},
-	{"X-Originating-IP": {"127.0.0.1"}},
-	{"X-Real-IP": {"127.0.0.1"}},
-	{"X-Remote-Addr": {"127.0.0.1"}},
-	{"X-Remote-Addr": {"localhost"}},
-	{"X-Remote-IP": {"127.0.0.1"}},
-	{"Redirect": {"127.0.0.1"}},
-	{"Referer": {"127.0.0.1"}},
-	{"X-Forwarded-Host": {"127.0.0.1"}},
-	{"X-Forwarded-Port": {"80"}},
-	{"X-True-IP": {"127.0.0.1"}},
-}
-
-var PathBypassPatterns = []string{
-	"%s/./%s",       // https://example.com/./admin
-	"%s/../%s",      // https://example.com/../admin
-	"%s/%%2e/%s",    // https://example.com/%2e/admin
-	"%s/%s/",        // https://example.com/admin/
-	"%s/%s%%20/",    // https://example.com/admin%20/
-	"%s/;/%s",       // https://example.com/;/admin
-	"%s/.;/%s",      // https://example.com/.;/admin
-	"%s//;//%s",     // https://example.com//;//admin
-	"%s//%s//",      // https://example.com//admin//
-	"%s/%s.json",    // https://example.com/admin.json
-	"%s/./%s/..",    // https://example.com/./admin/..
-	"%s/*%s",        // https://example.com/*admin/
-	"%s/%s*",        // https://example.com/admin/*
-	"%s/%%2f%s",     // https://example.com/%2fadmin/
-	"%s/%%2f%s%%2f", // https://example.com%2fadmin%2f
-	"%s//%s/./",     // https://example.com//admin/./
-	"%s///%s///",    // https://example.com///admin///
-	"%s/%s/;/",      // https://example.com/;/admin/
-	"%s//;//%s",     // https://example.com//;//admin/
-}
-
-var HttpMethods = [9]string{
-	"GET",
-	"POST",
-	"PUT",
-	"PATCH",
-	"DELETE",
-	"HEAD",
-	"OPTIONS",
-	"CONNECT",
-	"TRACE",
-}
 
 type Job struct {
 	BypassType string              //The type of bypass, (path, header or method)
@@ -91,27 +19,22 @@ type Job struct {
 
 func GenerateJobs(userConfig config.Config) chan Job {
 	jobs := make(chan Job, 1000)
-	defaultPath := fmt.Sprintf("%s/%s", userConfig.URL, userConfig.Path)
-	if userConfig.Path != "" {
-		bypassPaths := GenerateBypassPaths(userConfig.URL, userConfig.Path)
+	defaultURL := userConfig.DefaultURL()
 
-		//Genrates path bypass jobs
-		for _, url := range bypassPaths {
+	if userConfig.HasTargetSegment() {
+		for _, bypassURL := range generatePathBypassJobs(userConfig) {
 			job := Job{
 				BypassType: "path",
-				Bypass:     url,
-				URL:        url,
+				Bypass:     bypassURL,
+				URL:        bypassURL,
 				HttpMethod: "GET",
 				Headers:    userConfig.Headers,
 			}
 			jobs <- job
 		}
-
 	}
 
-	//Genrates header bypass jobs
-	for _, header := range BypassHeaders {
-
+	for _, header := range bypass.HeaderPayloads {
 		var bypassText string
 		for key, values := range header {
 			bypassText = fmt.Sprintf("%s: %s", key, strings.Join(values, ", "))
@@ -121,19 +44,18 @@ func GenerateJobs(userConfig config.Config) chan Job {
 		job := Job{
 			BypassType: "header",
 			Bypass:     bypassText,
-			URL:        defaultPath,
+			URL:        defaultURL,
 			HttpMethod: "GET",
 			Headers:    mergedHeaders,
 		}
 		jobs <- job
 	}
 
-	//Genrates http method bypass jobs
-	for _, method := range HttpMethods {
+	for _, method := range bypass.HTTPMethods {
 		job := Job{
 			BypassType: "method",
 			Bypass:     method,
-			URL:        defaultPath,
+			URL:        defaultURL,
 			HttpMethod: method,
 			Headers:    userConfig.Headers,
 		}
@@ -144,14 +66,45 @@ func GenerateJobs(userConfig config.Config) chan Job {
 	return jobs
 }
 
-func GenerateBypassPaths(url string, path string) []string {
-
-	var bypassPaths []string
-
-	bypassPaths = append(bypassPaths, fmt.Sprintf("%s/%s", url, strings.ToUpper(path)))
-
-	for _, pattern := range PathBypassPatterns {
-		bypassPaths = append(bypassPaths, fmt.Sprintf(pattern, url, path))
+func generatePathBypassJobs(cfg config.Config) []string {
+	target := cfg.TargetSegment()
+	if target == "" {
+		return nil
 	}
-	return bypassPaths
+
+	variants := make([]string, 0, len(bypass.PathPatterns)+1)
+
+	variants = append(variants, cfg.BuildURLForVariant(strings.ToUpper(target)))
+
+	prefixURL := cfg.TargetPrefixURL()
+	for _, pattern := range bypass.PathPatterns {
+		candidate := fmt.Sprintf(pattern, prefixURL, target)
+		candidate = cfg.AppendSuffixAndQuery(candidate)
+		variants = append(variants, candidate)
+	}
+
+	return deduplicate(variants)
+}
+
+func deduplicate(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	var result []string
+	for _, value := range values {
+		normalized := normalizeURL(value)
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func normalizeURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	parsed.Fragment = ""
+	return parsed.String()
 }


### PR DESCRIPTION
## Summary
- parse full URLs including query strings and fragments while allowing a specific path segment to be selected for fuzzing via new CLI flags
- generate bypass jobs with the preserved suffix path, share bypass payloads from a central package, and improve error handling
- refresh the README with conventional usage documentation

## Testing
- go build ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915902f1684832a914c786b71d310ac)